### PR TITLE
Fix NeoVim welcome screen on autostart

### DIFF
--- a/autoload/project.vim
+++ b/autoload/project.vim
@@ -75,7 +75,7 @@ endif
 
 if get(g:, 'project_enable_welcome', 1)
   au VimEnter *
-        \ if !argc() && (line2byte('$') == -1) && (v:progname =~? '^[gm]\=vim\%[\.exe]$') |
+        \ if !argc() && (line2byte('$') == -1) && (v:progname =~? '^[gmn]\=vim\%[\.exe]$') |
         \   call project#config#welcome() |
         \ endif
 endif


### PR DESCRIPTION
Nice update of the old vim plugin 'vim-project'. Love it!

This pull request reactivates the functionality of 'let g:project_enable_welcome = 0' for NeoVim.

(I copied the idea from a pull request of the original git repository.)
